### PR TITLE
Remove last reference to a specific coordinate name!

### DIFF
--- a/regionate/boundaries.py
+++ b/regionate/boundaries.py
@@ -54,8 +54,8 @@ def grid_boundaries_from_mask(grid, mask):
         j_c_list.append(j_c_new)
         
         idx = {
-            "xq":xr.DataArray(i_c_new, dims=("pt",)),
-            "yq":xr.DataArray(j_c_new, dims=("pt",))
+            grid.axes["X"].coords["outer"]:xr.DataArray(i_c_new, dims=("pt",)),
+            grid.axes["Y"].coords["outer"]:xr.DataArray(j_c_new, dims=("pt",))
         }
         lons_c_list.append(grid._ds["geolon_c"].isel(idx).values[:-1])
         lats_c_list.append(grid._ds["geolat_c"].isel(idx).values[:-1])

--- a/regionate/overlaps.py
+++ b/regionate/overlaps.py
@@ -2,7 +2,7 @@ import numpy as np
 from .utilities import *
 
 def find_indices_of_overlaps(r1, r2, closeness_threshold=5.e3, face_indices=False):
-    overlaps = haversine(
+    overlaps = distance_on_unit_sphere(
             r1.lons_c[:, np.newaxis], r1.lats_c[:, np.newaxis],
             r2.lons_c[np.newaxis, :], r2.lats_c[np.newaxis, :]
         ) < closeness_threshold
@@ -22,7 +22,7 @@ def group_overlaps(overlaps, r1, r2, closeness_threshold=5.e3):
     for o2 in overlaps[r2.name]:
         for o1 in overlaps[r1.name]:
             if np.any(o1) and np.any(o2):
-                if np.any(haversine(
+                if np.any(distance_on_unit_sphere(
                         r1.lons_c[o1, np.newaxis], r1.lats_c[o1, np.newaxis],
                         r2.lons_c[np.newaxis, o2], r2.lats_c[np.newaxis, o2]
                     ) < closeness_threshold):

--- a/regionate/region.py
+++ b/regionate/region.py
@@ -160,6 +160,10 @@ class GriddedRegion(Region):
         >>> lons, lats = np.array([-80., -66., -65.]), np.array([ 26.,  18.,  32.])
         >>> region = reg.Region('Bermuda Triangle', lons, lats, grid)
         """
+
+        if any([c not in grid._ds.coords for c in ["geolon_c", "geolat_c"]]):
+            raise ValueError("grid._ds must contain coordinates of grid cell corners, named 'geolon_c' and 'geolat_c'.")
+
         self.grid = grid
         self.save = {}
         

--- a/regionate/regions.py
+++ b/regionate/regions.py
@@ -161,6 +161,9 @@ class MaskRegions(GriddedRegions):
         `GriddedRegions` instance
         """
         
+        if any([c not in grid._ds.coords for c in ["geolon_c", "geolat_c"]]):
+            raise ValueError("grid._ds must contain coordinates of grid cell corners, named 'geolon_c' and 'geolat_c'.")
+
         self.grid = grid
         self.mask = mask
         

--- a/regionate/version.py
+++ b/regionate/version.py
@@ -1,3 +1,3 @@
 """regionate: version information"""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
Extends support to `xgcm.Grid` instances with different dimension name conventions than MOM6 (e.g. MITgcm's `XC` instead of MOM6's `xh`).

However, we still require there be coordinates named `geolon_c` and `geolat_c`. Probably somewhere in the code these are currently assumed to be two-dimensional (as in for curvilinear grids), but it would be nice to add a convenience function that just broadcasts singleton `lon` and `lat` since many regional models and output datasets still use rectilinear `lon,lat` grids.