### PR TITLE
Fix MaskRegions(2d_mask, 3d_grid): pad only axes the field spans (#24)

### DIFF
--- a/regionate/boundaries.py
+++ b/regionate/boundaries.py
@@ -99,8 +99,14 @@ def _pad_center(grid, da):
     `sectionate.gridutils.build_neighbor_maps`."""
     def _seam_or_fill(b):
         return b if (b == "periodic" or _is_fold_boundary(b)) else "fill"
-    padding = {ax: _seam_or_fill(grid.axes[ax].padding) for ax in grid.axes}
-    padding_width = {ax: (1, 1) for ax in grid.axes}
+    # Only pad axes whose dimensions `da` actually carries (issue #24): a center-point
+    # field spans just the horizontal (X/Y) tracer dims, but a 3D `grid` also declares a
+    # Z axis. Padding a Z axis absent from `da.dims` makes `xgcm.pad` raise
+    # `KeyError: None of the DataArray's dims (...) were found in axis coords`.
+    axes = [ax for ax in grid.axes
+            if set(grid.axes[ax].coords.values()) & set(da.dims)]
+    padding = {ax: _seam_or_fill(grid.axes[ax].padding) for ax in axes}
+    padding_width = {ax: (1, 1) for ax in axes}
     return pad(da, grid, padding_width, padding=padding, fill_value=np.nan)
 
 

--- a/regionate/tests/test_dimensionality.py
+++ b/regionate/tests/test_dimensionality.py
@@ -1,0 +1,78 @@
+"""Regression tests for issue #24: a 2D (X,Y) cell mask on a 3D (X,Y,Z) grid.
+
+`MaskRegions(2d_mask, 3d_grid)` used to crash inside `xgcm.pad` with
+`KeyError: "None of the DataArray's dims ('yh', 'xh') were found in axis coords."`
+because `regionate.boundaries._pad_center` iterated over EVERY axis in `grid.axes`
+(including the vertical Z axis) even though the center-point field it pads carries
+only the horizontal tracer dims. A budget over a horizontal region is a perfectly
+ordinary use of a 3D ocean grid, so the fix pads only the axes whose dims the field
+actually has, and the seam-aware mask/boundary answer must be identical to the one on
+the plain 2D grid (adding an unused Z axis changes nothing about horizontal topology).
+"""
+
+import numpy as np
+import xarray as xr
+import xgcm
+
+import regionate
+from regionate.boundaries import connected_components
+from regionate.tests.test_gridded_regions import initialize_spherical_grid
+from regionate.tests.test_connected_components import _mask_from_cells
+
+
+def _add_z_axis(grid_2d):
+    """Return a 3D `xgcm.Grid` identical to `grid_2d` but with an added vertical (Z)
+    axis (`zl` centers, `zi` interfaces). The X/Y coords dict mirrors
+    `initialize_spherical_grid` exactly, so the only difference is the extra Z axis."""
+    zi = np.array([0.0, 10.0, 30.0, 60.0])       # interfaces (Z outer)
+    zl = 0.5 * (zi[:-1] + zi[1:])                # centers (Z center)
+    ds = grid_2d._ds.copy()
+    ds = ds.assign_coords(
+        zl=xr.DataArray(zl, dims=("zl",)),
+        zi=xr.DataArray(zi, dims=("zi",)),
+    )
+    coords = {
+        "X": {"outer": "xq", "center": "xh"},
+        "Y": {"outer": "yq", "center": "yh"},
+        "Z": {"center": "zl", "outer": "zi"},
+    }
+    return xgcm.Grid(
+        ds, coords=coords,
+        padding={"X": "periodic", "Y": "extend", "Z": "extend"},
+        autoparse_metadata=False,
+    )
+
+
+def test_connected_components_ignores_unused_z_axis():
+    """Lowest-level reproduction: `connected_components` on a 2D mask must give the same
+    labeling on a 3D grid as on its 2D counterpart. Before the fix, the 3D call raised
+    a KeyError inside `_pad_center`; the 2D call was always fine."""
+    grid_2d = initialize_spherical_grid()
+    grid_3d = _add_z_axis(grid_2d)
+
+    # two clearly separated disks -> two components (cf. test_connected_components.py)
+    mask = _mask_from_cells(grid_2d, [(1, 1), (4, 4)])
+
+    labels_2d, ncomp_2d = connected_components(grid_2d, mask)
+    labels_3d, ncomp_3d = connected_components(grid_3d, mask)  # used to raise KeyError
+
+    assert ncomp_3d == ncomp_2d == 2
+    assert np.array_equal(labels_3d.transpose(*labels_2d.dims).values, labels_2d.values)
+
+
+def test_maskregions_ignores_unused_z_axis():
+    """End-to-end: `MaskRegions(2d_mask, 3d_grid)` must succeed and produce the same
+    region set as `MaskRegions(2d_mask, 2d_grid)`. Before the fix it raised a KeyError."""
+    grid_2d = initialize_spherical_grid()
+    grid_3d = _add_z_axis(grid_2d)
+
+    mask = _mask_from_cells(grid_2d, [(1, 1), (4, 4)])
+
+    regions_2d = regionate.MaskRegions(mask, grid_2d).region_dict
+    regions_3d = regionate.MaskRegions(mask, grid_3d).region_dict  # used to raise
+
+    assert len(regions_3d) == len(regions_2d) == 2
+    for key in regions_2d:
+        m2 = regions_2d[key].mask
+        m3 = regions_3d[key].mask
+        assert np.array_equal(m3.transpose(*m2.dims).values, m2.values)

--- a/regionate/version.py
+++ b/regionate/version.py
@@ -1,3 +1,3 @@
 """regionate: version information"""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/regionate/version.py
+++ b/regionate/version.py
@@ -1,3 +1,3 @@
 """regionate: version information"""
 
-__version__ = "0.6.1"
+__version__ = "0.6.0"


### PR DESCRIPTION
Fixes #24.

## Problem

`MaskRegions(2d_mask, 3d_grid)` crashed inside `xgcm.pad`:

```
KeyError: "None of the DataArray's dims ('yh', 'xh') were found in axis coords."
```

`regionate.boundaries._pad_center` built its `padding` / `padding_width` dicts by iterating over **every** axis in `grid.axes`. When a 3D grid declares a Z axis but the center-point field being padded carries only the horizontal tracer dims (`yh`, `xh`), `xgcm.pad` is handed a Z axis that isn't in the field's dims and raises. Tracing a horizontal region (e.g. an isobath / `deptho < 1000` mask) on a grid that also carries a vertical axis is an ordinary use case, and worked on 0.5.5.

## Fix

Restrict the padded axes to those whose dimension names actually intersect `da.dims`:

```python
axes = [ax for ax in grid.axes
        if set(grid.axes[ax].coords.values()) & set(da.dims)]
```

The `_seam_or_fill` seam-vs-fill logic and the NaN-fill behaviour are unchanged — only the set of iterated axes changes. Every padding path (`connected_components`, `_trace_and_drop`, `grid_boundaries_from_mask`) routes through `_pad_center`, so this single change covers all of them. This is the in-library equivalent of the temporary "build a 2D grid alongside the 3D one" workaround from the issue, so callers no longer need it.

## Tests

New `regionate/tests/test_dimensionality.py` builds a 3D grid by adding an (unused) Z axis to the existing `initialize_spherical_grid()` fixture and asserts a 2D mask yields an **identical** answer on the 3D grid as on the plain 2D grid — both at the `connected_components` level and end-to-end through `MaskRegions`. With the fix reverted, both tests fail with exactly the reported `KeyError`; with the fix they pass. Full suite: 48 passed, 10 skipped (real-data tests gated behind `REGIONATE_REALDATA_TESTS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)