### PR TITLE
Derive the version from the git tag instead of a checked-in file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,12 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          # `pip install -e .` resolves the version from the git tag via
+          # hatch-vcs; a shallow clone has no tag, so the installed package
+          # would report `0.1.devN` instead of the release line.
+          fetch-depth: 0
 
       - name: Conda setup
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,9 +8,14 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+      with:
+        # hatch-vcs derives the version from the git tag, which a shallow clone
+        # does not have. Without this the build silently produces a
+        # `0.0.0.dev...` artifact instead of the release version.
+        fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -19,6 +24,19 @@ jobs:
         pip install build twine
     - name: Build package
       run: python -m build
+    # Deriving the version from the tag should make this unfalsifiable, but it
+    # is the last point at which a mismatch is cheap to see: the alternative
+    # symptom is a 400 from PyPI at the very end of the release, and only when
+    # that version already exists.
+    - name: Built version must match the release tag
+      run: |
+        built=$(ls dist/*.tar.gz | sed -E 's|.*/regionate-(.*)\.tar\.gz|\1|')
+        tag="${GITHUB_REF_NAME#v}"
+        echo "tag=$tag built=$built"
+        if [ "$built" != "$tag" ]; then
+          echo "::error::Release tag $GITHUB_REF_NAME implies version '$tag', but the build produced '$built'."
+          exit 1
+        fi
     - name: Publish package
       env:
         TWINE_USERNAME: __token__

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .ipynb_checkpoints
 .DS_store
 __pycache__
+
+# Version file generated from the git tag by hatch-vcs at build time.
+regionate/_version.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,15 @@ build:
   os: ubuntu-24.04
   tools:
     python: "miniforge3-latest"
+  jobs:
+    post_checkout:
+      # RTD clones shallow, but installing regionate resolves its version from
+      # the git tag via hatch-vcs, and the docs are titled with it
+      # (`docs/source/conf.py` reads it from the installed metadata). Without
+      # the tag they would say `.devN`. Tolerate failure: an already-complete
+      # clone makes `--unshallow` an error, which must not fail the build.
+      - git fetch --unshallow || true
+      - git fetch --tags || true
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Adapted from the xgcm draft above; apply these when changing regionate's code.
 2. **Raise on bad input; never return a wrong answer.** regionate already does this — e.g. the corner-coordinate / grid validation the constructors run before building a mask. Keep it up: a silently wrong mask or boundary is worse than an exception in scientific software. On ambiguous/invalid/unsupported input, raise a specific error rather than guessing.
 3. **Do not grow core dependencies.** The core deps are `sectionate` (the sibling that owns grid-section tracing and transports), plus `pyproj`, `geopandas`, `regionmask`, and `contourpy` (see `pyproject.toml`). Prefer pushing grid/transport logic *down into `sectionate`* over adding new dependencies here. Before adding any import, confirm it isn't pulling in a heavy new dependency.
 4. **Every code change ships with tests.** Build test data from the synthetic grid fixtures in `regionate/tests/` (e.g. `initialize_spherical_grid()`) rather than hand-rolling datasets. For a bug fix, first write a test that fails, then make it pass. Exercise both construction directions (boundary→mask via `GriddedRegion`, mask→boundary via `MaskRegions`) and both orientations (clockwise/counterclockwise) where relevant.
-5. **Version by effort; breaking changes are allowed.** Bump `regionate/version.py` (`__version__`, read by hatchling). Favor a clean break (norm 1) over a compatibility shim.
+5. **Version by effort; breaking changes are allowed.** The version comes from the git tag, not from a file in the tree — see "Versioning" below, and do not add a literal back to `regionate/version.py`. Favor a clean break (norm 1) over a compatibility shim.
 
 ## Commands
 
@@ -35,6 +35,18 @@ pip install -e .                                # editable install (after creati
 ```
 
 Dev environment is conda-based (see README). CI (`.github/workflows/ci.yml`) installs `ci/environment.yml`, does `pip install -e .`, then runs `pytest` across Python 3.11–3.14. There is no linter configured.
+
+## Versioning
+
+**The git tag is the single source of truth.** `hatch-vcs` (`[tool.hatch.version] source = "vcs"`) derives the version from the tag at build time and writes it to `regionate/_version.py`, which is **gitignored** — there is no version string in the source tree. `regionate/version.py` is a thin shim that imports from it, with a `0.0.0+unknown` fallback for an un-built checkout.
+
+Consequences worth remembering when editing:
+
+- **Never add a version literal back to the tree**, and never "fix" a `0.0.0+unknown` by hardcoding one — it means the package was imported without being built or installed.
+- **Any CI job that installs the package needs `fetch-depth: 0`.** A shallow clone cannot see the tag, so hatch-vcs silently resolves a `0.1.devN` version instead of failing. The checkouts in `ci.yml` and `publish-to-pypi.yml` set it, and `.readthedocs.yaml` unshallows in `post_checkout` for the same reason. The same applies to a `pip install git+https://…` of a fork with no tags: it reports `0.1.devN`, which can fall below a downstream floor.
+- `_version.py` **is** shipped inside the sdist, so building from the sdist (as conda-forge does) works with no git present. Do not add it to `[tool.hatch.build] exclude`.
+- conda builds run with `--no-build-isolation`, so `hatch-vcs` must sit next to `hatchling` in the recipe's `host` requirements — in `conda/meta.yaml` here and on the conda-forge feedstock.
+- Releasing is just publishing a GitHub Release tagged `vX.Y.Z`; there is no bump commit. See "Releasing" in `README.md`.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -25,3 +25,37 @@ pip install -e .
 python -m ipykernel install --user --name docs_env_regionate --display-name "docs_env_regionate"
 jupyter-lab
 ```
+
+Releasing
+---------
+
+**The git tag is the version.** `regionate` has no version string checked into
+the source tree: `hatch-vcs` derives it from the tag at build time and writes
+`regionate/_version.py` (gitignored, but shipped inside the sdist and wheel). To
+cut a release you tag; there is no file to bump and nothing to keep in sync.
+
+1. Make sure `main` is green and has everything you want in the release.
+2. **Publish a GitHub Release** whose tag is `vX.Y.Z`, targeting the commit you
+   want to ship:
+   ```bash
+   gh release create vX.Y.Z --target "$(git rev-parse origin/main)" \
+     --title vX.Y.Z --generate-notes
+   ```
+   Publishing it (not merely pushing a tag) is what fires the workflow. Target
+   the commit you actually want: a tag placed *before* the commit you meant to
+   release builds the previous version, and PyPI rejects it as a duplicate.
+3. The **Publish to PyPI** workflow builds from that tag and uploads. It checks
+   out with `fetch-depth: 0` so the tag is visible to `hatch-vcs`, and asserts
+   that the built version matches the tag before publishing.
+4. Verify: <https://pypi.org/project/regionate/>.
+5. conda-forge builds from the PyPI sdist and lags by design; the autotick bot
+   opens the version-bump PR. Its recipe must list `hatch-vcs` alongside
+   `hatchling` in `host`, since it builds with `--no-build-isolation`.
+
+Two things follow from the tag being the version. Never add a version literal
+back to the tree — `regionate/version.py` is a shim over the generated file, and
+a `0.0.0+unknown` from it means the package was imported without being built or
+installed, not that a number is missing. And any checkout that installs the
+package needs its tags: a shallow clone, or a fork that never fetched them,
+resolves a `.devN` version instead of the release line. That is why CI checks out
+with `fetch-depth: 0` and Read the Docs unshallows in `post_checkout`.

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -20,6 +20,11 @@ requirements:
     - python {{ python_min }}
     - pip
     - hatchling
+    # The build backend resolves the version through hatch-vcs. The build above
+    # is `--no-build-isolation`, so it has to be installed here or the wheel
+    # build fails outright; the sdist carries the generated `_version.py`, so
+    # git itself is not needed.
+    - hatch-vcs
   run:
     - python >={{ python_min }}
     - pyproj

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,28 @@ dependencies = [
 "Sibling package" = "https://github.com/MOM6-community/sectionate"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
+# The version comes from the git tag, not from a file in the tree. Releasing is
+# then a single act -- tag `vX.Y.Z` and publish the GitHub Release -- with no
+# second commit to remember, and no way for the tag and the built artifact to
+# disagree about which version they are.
 [tool.hatch.version]
-path = "regionate/version.py"
+source = "vcs"
+
+# Drop the `+g<sha>` local segment. On a clean tag the version is exactly X.Y.Z
+# either way, but an untagged build would otherwise carry a PEP 440 *local*
+# version, which package indexes refuse outright. Untagged builds are
+# `X.Y.Z.devN` instead, which an index will accept.
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
+
+# Building writes the resolved version to `regionate/_version.py`, which is
+# gitignored but *is* included in the sdist -- so `pip install` from the sdist,
+# and conda-forge's build from the PyPI sdist, both work without git present.
+[tool.hatch.build.hooks.vcs]
+version-file = "regionate/_version.py"
 
 [tool.hatch.build]
 exclude = ["examples/**", "data/**"]

--- a/regionate/version.py
+++ b/regionate/version.py
@@ -1,3 +1,18 @@
-"""regionate: version information"""
+"""regionate: version information.
 
-__version__ = "0.5.5"
+The version is derived from the git tag at build time by ``hatch-vcs``, which
+writes the resolved value to ``regionate/_version.py``. That file is generated
+rather than checked in: there is deliberately no version string in the source
+tree that could drift out of step with the tag it is supposed to describe.
+
+``_version.py`` ships in every built artifact -- wheel, sdist, and editable
+install -- so the fallback below only fires when ``regionate`` is imported
+straight from a source checkout that has never been built or installed.
+"""
+
+try:
+    from regionate._version import __version__
+except ImportError:  # pragma: no cover - un-built source checkout
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]


### PR DESCRIPTION
Ports the scheme from [hdrake/xeos#10](https://github.com/hdrake/xeos/pull/10) to `regionate`: the version is derived from the git tag by `hatch-vcs` instead of being read from a literal in `regionate/version.py`.

## Why

`regionate/version.py` held `__version__ = "0.5.5"`, which had to be bumped in its own commit before every release (engineering norm 5 said exactly that). Nothing tied that commit to the tag the release was actually cut from, so the two could disagree — and when they did, the symptom was a `400 File already exists` from PyPI at the very end of the release. That is exactly how the `xeos` v0.2.1 release failed: the tag was placed one commit before the bump, the workflow built the previous version, and PyPI rejected it.

With the tag as the source of truth, tagging **is** the bump. There is no second commit to remember and no way for the tag and the artifact to disagree.

## What changed

- **`pyproject.toml`** — `hatch-vcs` added to `build-system.requires`; `[tool.hatch.version]` switches from `path = "regionate/version.py"` to `source = "vcs"`; `local_scheme = "no-local-version"` so untagged builds are `X.Y.Z.devN` rather than PEP 440 local versions that indexes refuse; a build hook writes the resolved version to `regionate/_version.py`.
- **`regionate/version.py`** — now a shim that imports from the generated `_version.py`, with a `0.0.0+unknown` fallback for a checkout that has never been built or installed. `regionate.__version__` is unchanged for anything installed from a release.
- **`.gitignore`** — ignores the generated `regionate/_version.py`.
- **`.github/workflows/publish-to-pypi.yml`** — `fetch-depth: 0` (a shallow clone has no tag, so the build would silently produce a `.devN` artifact), plus a step asserting the built version matches the release tag. `checkout`/`setup-python` bumped off the long-EOL v2.
- **`.github/workflows/ci.yml`** — `fetch-depth: 0` on the checkout, since the job installs the package.
- **`.readthedocs.yaml`** — `post_checkout` unshallows and fetches tags. `docs/source/conf.py` titles the pages with the installed version, so without this they would read `.devN`.
- **`conda/meta.yaml`** — `hatch-vcs` added to `host`. The recipe builds with `--no-build-isolation`, so the backend's requirements must be installed there; I confirmed locally that without it the wheel build fails in `hatchling.builders.plugin.interface.get_build_hooks`. The same addition is needed on [conda-forge/regionate-feedstock](https://github.com/conda-forge/regionate-feedstock) before the next release builds.
- **`README.md`** — a `Releasing` section documenting the tag-is-the-version procedure.
- **`CLAUDE.md`** — a `Versioning` section with the invariants, and norm 5 restated (there is no longer a literal to bump).

## Verified locally

- Clean tag → exact version: building at a throwaway `v9.9.9` produces `regionate-9.9.9.tar.gz` / `.whl`, no suffix, with the generated `regionate/_version.py` inside the sdist.
- Untagged `main` builds as `0.5.6.devN` (last tag `v0.5.5` + distance).

## Note on untagged checkouts

A checkout without tags — a shallow clone, or a **fork** that never fetched them — now resolves a `.devN` version rather than the release line. CI and Read the Docs are handled above. The one to watch is `pip install git+https://github.com/<fork>/regionate.git@<branch>`: if that fork has no tags it reports `0.1.devN`, which can fall below a downstream `regionate >= 0.5.5` floor and get silently replaced by the PyPI build. Pushing the release tags to the fork (`git push <fork> --tags`) fixes it; otherwise install such a branch last with `--force-reinstall --no-deps`, exactly as regionate's own dev branches already do for `xgcm`.


## CI is red for an unrelated, pre-existing reason

The four `build` jobs fail on `ValueError: Argument 'boundary' has been renamed to
'padding'` from `xgcm/grid.py` — an xgcm 1.0 API break in
`regionate/tests/test_gridded_regions.py`. `main` is **already red for the same
reason**: the last push run (`Add AI Usage Policy and engineering norms to CLAUDE.md`,
2026-07-13) failed identically. Nothing in this PR touches Python outside
`version.py`.

What this PR *is* responsible for did pass in those same runs: `pip install -e .`
resolved the version from the tag, and `conda list` reports `regionate 0.5.6.dev9` —
the tag `v0.5.5` plus distance, which is exactly right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
