### PR TITLE
Cover GriddedRegion on a 3D grid, the path #24's tests missed

### DIFF
--- a/regionate/tests/test_dimensionality.py
+++ b/regionate/tests/test_dimensionality.py
@@ -76,3 +76,32 @@ def test_maskregions_ignores_unused_z_axis():
         m2 = regions_2d[key].mask
         m3 = regions_3d[key].mask
         assert np.array_equal(m3.transpose(*m2.dims).values, m2.values)
+
+
+def test_gridded_region_ignores_unused_z_axis():
+    """`GriddedRegion` traces its boundary with `sectionate.grid_section`, which builds
+    topology-aware neighbor maps -- a code path neither `connected_components` nor
+    `MaskRegions` above ever reaches.
+
+    That gap is why this file, written for #24, did not catch the *same* bug in
+    sectionate: `sectionate.gridutils` requested a halo on every registered axis in
+    exactly the way `_pad_center` used to, and a 3D grid raised the same `KeyError`
+    from `grid_section` (MOM6-community/sectionate#52). The two libraries had one bug
+    between them and only one of them was fixed.
+    """
+    grid_2d = initialize_spherical_grid()
+    grid_3d = _add_z_axis(grid_2d)
+
+    # a closed zonal loop around the sphere, as in test_gridded_regions.py
+    lons = np.array([0., 120., 240., 360.])
+    lats = np.array([0., 0., 0., 0.])
+
+    region_2d = regionate.GriddedRegion("box", lons, lats, grid_2d)
+    region_3d = regionate.GriddedRegion("box", lons, lats, grid_3d)  # used to raise
+
+    np.testing.assert_array_equal(region_3d.i_c, region_2d.i_c)
+    np.testing.assert_array_equal(region_3d.j_c, region_2d.j_c)
+    np.testing.assert_array_equal(region_3d.lons_c, region_2d.lons_c)
+    np.testing.assert_array_equal(region_3d.lats_c, region_2d.lats_c)
+    m2, m3 = region_2d.mask, region_3d.mask
+    assert np.array_equal(m3.transpose(*m2.dims).values, m2.values)


### PR DESCRIPTION
Adds the one case `test_dimensionality.py` was missing. **Blocked on MOM6-community/sectionate#52 — it will fail CI until that fix lands. Draft until then.**

### Why

This file was written for #24: `regionate.boundaries._pad_center` iterated every axis of the grid while padding a field carrying only the horizontal tracer dims, so a 2-D mask on a 3-D grid raised

```
KeyError: "None of the DataArray's dims ('yh', 'xh') were found in axis coords."
```

That was fixed here, with the two tests in this file. Both go through `connected_components` and `MaskRegions`, which stay inside `regionate.boundaries`. Neither builds a `GriddedRegion` — and that is the path that calls `sectionate.grid_section`, and so `sectionate.gridutils.build_neighbor_maps`.

`build_neighbor_maps` had the identical bug: `padding_width = {ax: (1, 1) for ax in grid.axes}` on a horizontal-only index array, at three sites. So the same defect existed in both libraries, was diagnosed and fixed in this one, and survived untouched in the sibling — because the regression test stopped one function short of the boundary between them. I confirmed the existing two tests pass unchanged against stock sectionate 0.4.0rc1.

Coverage counts, for context: across regionate's tests and examples there are 15 `xgcm.Grid` constructions and this file holds the only one that registers a `Z` axis; across sectionate's 33, none do.

### The test

`test_gridded_region_ignores_unused_z_axis` builds a `GriddedRegion` from the same lons/lats on `initialize_spherical_grid()` and on its `_add_z_axis(...)` counterpart, and requires identical `i_c`, `j_c`, `lons_c`, `lats_c` and mask — the same "an unused vertical axis changes nothing about horizontal topology" contract the existing tests assert, extended to the entry point that crosses into sectionate.

### Status

| | stock sectionate 0.4.0rc1 | with the sectionate#52 fix |
| --- | --- | --- |
| existing 2 tests in this file | pass | pass |
| new `test_gridded_region_ignores_unused_z_axis` | **fails** (`KeyError`) | passes |
| full regionate suite | — | 49 passed, 10 skipped |

The 10 skips are the opt-in real-data tests (`REGIONATE_REALDATA_TESTS=1`), unrelated to this change.

CI installs sectionate from `hdrake/sectionate@topology-driven-neighbors`, which does not yet carry the fix — it is on `fix-horizontal-only-padding` (hdrake/sectionate#8). **This should merge only after that one**, which is why it is a draft. It is deliberately a cross-library contract test: its job is to fail if sectionate ever regresses this, which is precisely what nothing caught the first time.

<sub>Drafted with AI assistance (Claude Code). I have read the diff and ran the tests myself.</sub>
